### PR TITLE
Update obj_Drones.iss

### DIFF
--- a/core/obj_Drones.iss
+++ b/core/obj_Drones.iss
@@ -132,7 +132,7 @@ objectdef obj_Configuration_DroneData
 			     ${Drones.Value.FindAttribute[Type].String.Find[${affix}]}) || \
 			    ((${isNavy} && \
 			     (${Drones.Value.FindAttribute[Type].String.Find[Navy]} || \
-			      ${Drones.Value.FindAttribute[Type].String.Find[Fleet]})))
+			      ${Drones.Value.FindAttribute[Type].String.Find[Fleet]}))))
 			{
 				return ${Drones.Value.FindAttribute[Type].String}
 			}


### PR DESCRIPTION
Missing a ")" can cause faction drones to not work.